### PR TITLE
Get mdns-publisher via multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,8 @@ RUN git clone https://github.com/nginx-proxy/forego/ \
    && rm -rf /go/forego
 
 
-FROM python:3.11.4-slim-bullseye
+FROM python:3.11-slim-bullseye
 LABEL maintainer="Ben Hardill hardillb@gmail.com"
-
-RUN apt-get update && apt-get install -y gcc libdbus-1-dev libdbus-glib-1-dev \
-&& rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 
@@ -49,8 +46,6 @@ COPY avahi.tmpl .
 COPY cname.py .
 COPY restart.sh .
 RUN touch ./cnames
-
-RUN pip install mdns-publisher
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN git clone https://github.com/nginx-proxy/forego/ \
 FROM python:3.11.4-slim-bullseye
 LABEL maintainer="Ben Hardill hardillb@gmail.com"
 
-RUN apt-get update && apt-get install -y build-essential ninja-build patchelf cmake libdbus-1-dev libdbus-glib-1-dev \
+RUN apt-get update && apt-get install -y gcc libdbus-1-dev libdbus-glib-1-dev \
 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG DOCKER_GEN_VERSION=0.10.6
 ARG FOREGO_VERSION=v0.17.2
+ARG PYTHON_VER=3.11
 
 FROM golang:1.20 as gobuilder
 
@@ -32,14 +33,21 @@ RUN git clone https://github.com/nginx-proxy/forego/ \
    && cd - \
    && rm -rf /go/forego
 
+FROM python:${PYTHON_VER} as pythonbuilder
+RUN apt-get update && apt-get install -y build-essential libdbus-1-dev
+RUN pip install mdns-publisher
 
-FROM python:3.11-slim-bullseye
+FROM python:${PYTHON_VER}-slim
 LABEL maintainer="Ben Hardill hardillb@gmail.com"
+ARG PYTHON_VER
 
-WORKDIR /usr/src/app
+RUN apt-get update && apt-get install -y libdbus-1-3 && rm -rf /var/lib/apt/lists/*
 
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego
 COPY --from=dockergen /usr/local/bin/docker-gen  /usr/local/bin/docker-gen
+COPY --from=pythonbuilder /usr/local/lib/python${PYTHON_VER}/site-packages/ /usr/local/lib/python${PYTHON_VER}/site-packages/
+
+WORKDIR /usr/src/app
 
 COPY Procfile .
 COPY avahi.tmpl .

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone https://github.com/nginx-proxy/forego/ \
    && rm -rf /go/forego
 
 FROM python:${PYTHON_VER} as pythonbuilder
-RUN apt-get update && apt-get install -y build-essential libdbus-1-dev
+RUN apt-get update && apt-get install -y build-essential libdbus-1-dev cmake
 RUN pip install mdns-publisher
 
 FROM python:${PYTHON_VER}-slim


### PR DESCRIPTION
Removed pkgs and pip to thin this down much further now, also note I snuck in a change to pin us to a less specific version of Python